### PR TITLE
Break dep cycle, allow most to use mostjs/multicast

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
-import {Stream} from 'most'
 import MulticastSource from './MulticastSource'
 
 function multicast (stream) {
   const source = stream.source
   return source instanceof MulticastSource
     ? stream
-    : new Stream(new MulticastSource(source))
+    : new stream.constructor(new MulticastSource(source))
 }
 
 export {multicast as default, MulticastSource}


### PR DESCRIPTION
This allows `most` to depend on `@most/multicast`.  Ultimately, we'll likely end up with a different solution, by creating a `@most/stream` package containing the core stream type.  For now, tho, this solves the immediate issue.
