### PR TITLE
Remove try/catch for single observer case

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "assert": "^1.3.0",
     "babel-cli": "^6.5.1",
     "babel-core": "^6.4.5",
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.0",
     "babel-plugin-transform-es2015-modules-umd": "^6.4.3",
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.2",

--- a/src/MulticastSource.js
+++ b/src/MulticastSource.js
@@ -37,7 +37,7 @@ export default class MulticastSource {
   event (time, value) {
     const s = this.sinks
     if (s.length === 1) {
-      tryEvent(time, value, s[0])
+      s[0].event(time, value)
       return
     }
     for (let i = 0; i < s.length; ++i) {
@@ -48,7 +48,7 @@ export default class MulticastSource {
   end (time, value) {
     const s = this.sinks
     if (s.length === 1) {
-      tryEnd(time, value, s[0])
+      s[0].end(time, value)
       return
     }
     for (let i = 0; i < s.length; ++i) {
@@ -58,10 +58,6 @@ export default class MulticastSource {
 
   error (time, err) {
     const s = this.sinks
-    if (s.length === 1) {
-      s[0].error(time, err)
-      return
-    }
     for (let i = 0; i < s.length; ++i) {
       s[i].error(time, err)
     }


### PR DESCRIPTION
In the case where there's only one observer, we can remove try/catch since there's no way for an error in that observer to interfere with other observers (since there are no other observers!).  This prevents deoptimization in the one-observer case.
