### PR TITLE
Dispose only once to avoid race condition

### DIFF
--- a/src/MulticastDisposable.js
+++ b/src/MulticastDisposable.js
@@ -2,11 +2,15 @@ export default class MulticastDisposable {
   constructor (source, sink) {
     this.source = source
     this.sink = sink
+    this.disposed = false
   }
 
   dispose () {
-    const s = this.source
-    const remaining = s.remove(this.sink)
-    return remaining === 0 && s._dispose()
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
+    const remaining = this.source.remove(this.sink)
+    return remaining === 0 && this.source._dispose()
   }
 }

--- a/test/MulticastDisposable-test.js
+++ b/test/MulticastDisposable-test.js
@@ -1,0 +1,77 @@
+import {describe, it} from 'mocha'
+import assert from 'assert'
+
+import MulticastDisposable from '../src/MulticastDisposable'
+
+describe('MulticastDisposable', () => {
+  it('should dispose when sinks reaches zero', () => {
+    const expectedSink = {}
+    const expectedResult = {}
+    let removeCalled = 0
+    const source = {
+      remove (sink) {
+        removeCalled += 1
+        assert.strictEqual(expectedSink, sink)
+        return 0
+      },
+
+      _dispose () {
+        return expectedResult
+      }
+    }
+
+    const md = new MulticastDisposable(source, expectedSink)
+
+    const result = md.dispose()
+
+    assert.strictEqual(1, removeCalled)
+    assert.strictEqual(expectedResult, result)
+  })
+
+  it('should not dispose when sinks > 0', () => {
+    const expectedSink = {}
+    const failedResult = {}
+    let removeCalled = 0
+    const source = {
+      remove (sink) {
+        removeCalled += 1
+        assert.strictEqual(expectedSink, sink)
+        return 1
+      },
+
+      _dispose () {
+        return failedResult
+      }
+    }
+
+    const md = new MulticastDisposable(source, expectedSink)
+
+    const result = md.dispose()
+
+    assert.strictEqual(1, removeCalled)
+    assert.notStrictEqual(failedResult, result)
+  })
+
+  it('should dispose only once', () => {
+    const expectedSink = {}
+    const expectedResult = {}
+    let disposeCalled = 0
+    const source = {
+      remove (sink) {
+        return 0
+      },
+
+      _dispose () {
+        disposeCalled += 1
+        return expectedResult
+      }
+    }
+
+    const md = new MulticastDisposable(source, expectedSink)
+
+    md.dispose()
+    md.dispose()
+
+    assert.strictEqual(1, disposeCalled)
+  })
+})


### PR DESCRIPTION
This adds logic to MulticastDisposable similar to that of most core's [`dispose.once`](https://github.com/cujojs/most/blob/master/lib/disposable/dispose.js#L111), so that dispose is idempotent.  Unit tests included.

Fix #11
