### PR TITLE
Use a fast property for first observer

### DIFF
--- a/src/MulticastSource.js
+++ b/src/MulticastSource.js
@@ -6,6 +6,7 @@ import { append, remove, findIndex } from '@most/prelude'
 export default class MulticastSource {
   constructor (source) {
     this.source = source
+    this.sink = undefined
     this.sinks = []
     this._disposable = emptyDisposable
   }
@@ -25,39 +26,52 @@ export default class MulticastSource {
   }
 
   add (sink) {
+    if (this.sink === undefined) {
+      this.sink = sink
+      return 1
+    }
+
     this.sinks = append(sink, this.sinks)
-    return this.sinks.length
+    return this.sinks.length + 1
   }
 
   remove (sink) {
+    if (sink === this.sink) {
+      this.sink = this.sinks.shift()
+      return this.sink === undefined ? 0 : this.sinks.length + 1
+    }
+
     this.sinks = remove(findIndex(sink, this.sinks), this.sinks)
-    return this.sinks.length
+    return this.sinks.length + 1
   }
 
   event (time, value) {
     const s = this.sinks
-    if (s.length === 1) {
-      s[0].event(time, value)
-      return
-    }
-    for (let i = 0; i < s.length; ++i) {
-      tryEvent(time, value, s[i])
+    if (s.length === 0) {
+      this.sink.event(time, value)
+    } else {
+      tryEvent(time, value, this.sink)
+      for (let i = 0; i < s.length; ++i) {
+        tryEvent(time, value, s[i])
+      }
     }
   }
 
   end (time, value) {
-    const s = this.sinks
-    if (s.length === 1) {
-      s[0].end(time, value)
-      return
-    }
+    // Important: slice first since sink.end may change
+    // the set of sinks
+    const s = this.sinks.slice()
+    tryEnd(time, value, this.sink)
     for (let i = 0; i < s.length; ++i) {
       tryEnd(time, value, s[i])
     }
   }
 
   error (time, err) {
-    const s = this.sinks
+    // Important: slice first since sink.error may change
+    // the set of sinks
+    const s = this.sinks.slice()
+    this.sink.error(time, err)
     for (let i = 0; i < s.length; ++i) {
       s[i].error(time, err)
     }


### PR DESCRIPTION
This can make a significant difference in the case where there is exactly one observer, and doesn't seem to hurt the multiple-observer case.  The tradeoff is a bit more code in the add/remove methods.  Maybe it's worth it?

I'll post some perf numbers for comparison.
