### PR TITLE
Use persistent sink list structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build-dist && uglifyjs dist/multicast.js -o dist/multicast.min.js",
     "prepublish": "npm run build",
     "preversion": "npm run build",
-    "unit-test": "babel-node ./node_modules/.bin/isparta cover _mocha",
+    "unit-test": "babel-node ./node_modules/.bin/isparta cover _mocha -- --reporter dot",
     "lint": "jsinspect src && jsinspect test && eslint src test",
     "test": "npm run lint && npm run unit-test"
   },

--- a/src/MulticastSource.js
+++ b/src/MulticastSource.js
@@ -21,7 +21,7 @@ export default class MulticastSource {
 
   _dispose () {
     const disposable = this._disposable
-    this._disposable = void 0
+    this._disposable = emptyDisposable
     this.sink = none()
     return Promise.resolve(disposable).then(dispose)
   }

--- a/src/MulticastSource.js
+++ b/src/MulticastSource.js
@@ -35,6 +35,7 @@ export default class MulticastSource {
   remove (sink) {
     const s = this.sink
     this.sink = removeSink(sink, this.sink)
+    // istanbul ignore else
     if (s !== this.sink) {
       this.activeCount -= 1
     }

--- a/src/MulticastSource.js
+++ b/src/MulticastSource.js
@@ -1,13 +1,12 @@
 import MulticastDisposable from './MulticastDisposable'
-import { tryEvent, tryEnd } from './tryEvent'
 import { dispose, emptyDisposable } from './dispose'
-import { append, remove, findIndex } from '@most/prelude'
+import { none, addSink, removeSink } from './sink'
 
 export default class MulticastSource {
   constructor (source) {
     this.source = source
-    this.sink = undefined
-    this.sinks = []
+    this.sink = none()
+    this.activeCount = 0
     this._disposable = emptyDisposable
   }
 
@@ -16,69 +15,41 @@ export default class MulticastSource {
     if (n === 1) {
       this._disposable = this.source.run(this, scheduler)
     }
+
     return new MulticastDisposable(this, sink)
   }
 
   _dispose () {
     const disposable = this._disposable
     this._disposable = void 0
+    this.sink = none()
     return Promise.resolve(disposable).then(dispose)
   }
 
   add (sink) {
-    if (this.sink === undefined) {
-      this.sink = sink
-      return 1
-    }
-
-    this.sinks = append(sink, this.sinks)
-    return this.sinks.length + 1
+    this.sink = addSink(sink, this.sink)
+    this.activeCount += 1
+    return this.activeCount
   }
 
   remove (sink) {
-    if (sink === this.sink) {
-      this.sink = this.sinks.shift()
-      return this.sink === undefined ? 0 : this.sinks.length + 1
+    const s = this.sink
+    this.sink = removeSink(sink, this.sink)
+    if (s !== this.sink) {
+      this.activeCount -= 1
     }
-
-    this.sinks = remove(findIndex(sink, this.sinks), this.sinks)
-    return this.sinks.length + 1
+    return this.activeCount
   }
 
-  event (time, value) { // eslint-disable-line complexity
-    if (this.sink === undefined) {
-      return
-    }
-
-    const s = this.sinks
-    if (s.length === 0) {
-      this.sink.event(time, value)
-      return
-    }
-
-    tryEvent(time, value, this.sink)
-    for (let i = 0; i < s.length; ++i) {
-      tryEvent(time, value, s[i])
-    }
+  event (time, value) {
+    this.sink.event(time, value)
   }
 
   end (time, value) {
-    // Important: slice first since sink.end may change
-    // the set of sinks
-    const s = this.sinks.slice()
-    tryEnd(time, value, this.sink)
-    for (let i = 0; i < s.length; ++i) {
-      tryEnd(time, value, s[i])
-    }
+    this.sink.end(time, value)
   }
 
   error (time, err) {
-    // Important: slice first since sink.error may change
-    // the set of sinks
-    const s = this.sinks.slice()
     this.sink.error(time, err)
-    for (let i = 0; i < s.length; ++i) {
-      s[i].error(time, err)
-    }
   }
 }

--- a/src/sink.js
+++ b/src/sink.js
@@ -4,7 +4,7 @@ import { tryEvent, tryEnd } from './tryEvent'
 export const addSink = (sink, sinks) =>
   sinks === NONE ? sink
     : sinks instanceof Many ? new Many(append(sink, sinks.sinks))
-    : new Many([sink, sinks])
+    : new Many([sinks, sink])
 
 export const removeSink = (sink, sinks) => // eslint-disable-line complexity
   sinks === NONE || sink === sinks ? NONE
@@ -19,8 +19,9 @@ const removeMany = (sink, many) => {
 
 const removeManyAt = (i, sinks) => {
   const updated = remove(i, sinks)
-  return updated.length === 0 ? NONE
-    : updated.length === 1 ? updated[0]
+  // It's impossible to create a Many with 1 sink
+  // so we can't end up with updated.length === 0 here
+  return updated.length === 1 ? updated[0]
     : new Many(updated)
 }
 

--- a/src/sink.js
+++ b/src/sink.js
@@ -1,0 +1,61 @@
+import { append, remove, findIndex } from '@most/prelude'
+import { tryEvent, tryEnd } from './tryEvent'
+
+export const addSink = (sink, sinks) =>
+  sinks === NONE ? sink
+    : sinks instanceof Many ? new Many(append(sink, sinks.sinks))
+    : new Many([sink, sinks])
+
+export const removeSink = (sink, sinks) => // eslint-disable-line complexity
+  sinks === NONE || sink === sinks ? NONE
+    : sinks instanceof Many ? removeMany(sink, sinks)
+    : sinks
+
+const removeMany = (sink, many) => {
+  const { sinks } = many
+  const i = findIndex(sink, sinks)
+  return i < 0 ? many : removeManyAt(i, sinks)
+}
+
+const removeManyAt = (i, sinks) => {
+  const updated = remove(i, sinks)
+  return updated.length === 0 ? NONE
+    : updated.length === 1 ? updated[0]
+    : new Many(updated)
+}
+
+class None {
+  event (t, x) {}
+  end (t, x) {}
+  error (t, x) {}
+}
+
+const NONE = new None()
+export const none = () => NONE
+
+class Many {
+  constructor (sinks) {
+    this.sinks = sinks
+  }
+
+  event (t, x) {
+    const s = this.sinks
+    for (let i = 0; i < s.length; ++i) {
+      tryEvent(t, x, s[i])
+    }
+  }
+
+  end (t, x) {
+    const s = this.sinks
+    for (let i = 0; i < s.length; ++i) {
+      tryEnd(t, x, s[i])
+    }
+  }
+
+  error (t, x) {
+    const s = this.sinks
+    for (let i = 0; i < s.length; ++i) {
+      s[i].error(t, x)
+    }
+  }
+}

--- a/test/sink-test.js
+++ b/test/sink-test.js
@@ -1,0 +1,63 @@
+import {describe, it} from 'mocha'
+import assert from 'assert'
+
+import { none, addSink, removeSink } from '../src/sink'
+
+describe('none', () => {
+  it('should compare by value', () => {
+    assert.strictEqual(none(), none())
+  })
+
+  it('should return undefined from event, end, error', () => {
+    assert.strictEqual(undefined, none().event(0, 0))
+    assert.strictEqual(undefined, none().end(0, 0))
+    assert.strictEqual(undefined, none().error(0, 0))
+  })
+})
+
+describe('addSink', () => {
+  it('should return sink when adding to none', () => {
+    const sink = {}
+    assert.strictEqual(sink, addSink(sink, none()))
+  })
+
+  it('should return many when adding to sink', () => {
+    const sink1 = {}
+    const sink2 = {}
+    const result = addSink(sink2, addSink(sink1, none()))
+    assert.strictEqual(sink1, result.sinks[0])
+    assert.strictEqual(sink2, result.sinks[1])
+  })
+})
+
+describe('removeSink', () => {
+  it('should return none when removing from none', () => {
+    assert.strictEqual(none(), removeSink({}, none()))
+  })
+
+  it('should return sink when removing unknown from sink', () => {
+    const sink = {}
+    assert.strictEqual(sink, removeSink({}, sink))
+  })
+
+  it('should return sink when removing from many with 2', () => {
+    const sink1 = {}
+    const sink2 = {}
+    const sink = addSink(sink2, addSink(sink1, none()))
+
+    const result1 = removeSink(sink2, sink)
+    assert.strictEqual(sink1, result1)
+
+    const result2 = removeSink(sink1, sink)
+    assert.strictEqual(sink2, result2)
+  })
+
+  it('should return sinks when removing unknown from many', () => {
+    const sink1 = {}
+    const sink2 = {}
+    const sink = addSink(sink2, addSink(sink1, none()))
+
+    const result = removeSink({}, sink)
+    assert.strictEqual(sink, result)
+  })
+})


### PR DESCRIPTION
This introduces a new immutable persistent data structure and operations for tracking sinks.  It further optimizes the single-sink case, without sacrificing performance in multi-sink cases.

Using most 0.19.3, adding multicast to the [filter-map-reduce test](https://github.com/cujojs/most/tree/master/test/perf#node), adds almost no overhead for the single-sink case:

```
filter -> map -> reduce 1000000 integers
-------------------------------------------------------
most                499.77 op/s ±  1.12%   (79 samples)
```

Fix #14 
