### PR TITLE
Simplify using just an array

### DIFF
--- a/src/MulticastSource.js
+++ b/src/MulticastSource.js
@@ -6,7 +6,6 @@ import { append, remove, findIndex } from '@most/prelude'
 export default class MulticastSource {
   constructor (source) {
     this.source = source
-    this.sink = undefined
     this.sinks = []
     this._disposable = emptyDisposable
   }
@@ -21,62 +20,44 @@ export default class MulticastSource {
 
   _dispose () {
     const disposable = this._disposable
-    this._disposable = void 0
+    this._disposable = emptyDisposable
     return Promise.resolve(disposable).then(dispose)
   }
 
   add (sink) {
-    if (this.sink === undefined) {
-      this.sink = sink
-      return 1
-    }
-
     this.sinks = append(sink, this.sinks)
-    return this.sinks.length + 1
+    return this.sinks.length
   }
 
   remove (sink) {
-    if (sink === this.sink) {
-      this.sink = this.sinks.shift()
-      return this.sink === undefined ? 0 : this.sinks.length + 1
+    const i = findIndex(sink, this.sinks)
+    // istanbul ignore next
+    if (i >= 0) {
+      this.sinks = remove(i, this.sinks)
     }
 
-    this.sinks = remove(findIndex(sink, this.sinks), this.sinks)
-    return this.sinks.length + 1
+    return this.sinks.length
   }
 
-  event (time, value) { // eslint-disable-line complexity
-    if (this.sink === undefined) {
-      return
-    }
-
+  event (time, value) {
     const s = this.sinks
-    if (s.length === 0) {
-      this.sink.event(time, value)
-      return
+    if (s.length === 1) {
+      return s[0].event(time, value)
     }
-
-    tryEvent(time, value, this.sink)
     for (let i = 0; i < s.length; ++i) {
       tryEvent(time, value, s[i])
     }
   }
 
   end (time, value) {
-    // Important: slice first since sink.end may change
-    // the set of sinks
-    const s = this.sinks.slice()
-    tryEnd(time, value, this.sink)
+    const s = this.sinks
     for (let i = 0; i < s.length; ++i) {
       tryEnd(time, value, s[i])
     }
   }
 
   error (time, err) {
-    // Important: slice first since sink.error may change
-    // the set of sinks
-    const s = this.sinks.slice()
-    this.sink.error(time, err)
+    const s = this.sinks
     for (let i = 0; i < s.length; ++i) {
       s[i].error(time, err)
     }


### PR DESCRIPTION
This is an alternative to #15.  It's not nearly as performant for the single-sink case.  However, it's equivalent for multi-sink case.

Here are results for 2, 3, 4, 5 and 10 sinks for this PR:

```
multicast -> combine(addAll)100000 x 2 integers
-------------------------------------------------------
most                159.39 op/s ±  2.05%   (75 samples)

multicast -> combine(addAll)100000 x 3 integers
-------------------------------------------------------
most                102.98 op/s ±  1.67%   (78 samples)

multicast -> combine(addAll)100000 x 4 integers
-------------------------------------------------------
most                 78.61 op/s ±  1.90%   (73 samples)

multicast -> combine(addAll)100000 x 5 integers
-------------------------------------------------------
most                 53.13 op/s ±  1.70%   (72 samples)

multicast -> combine(addAll)100000 x 10 integers
-------------------------------------------------------
most                  6.94 op/s ±  1.52%   (37 samples)
```

And using #15:

```
multicast -> combine(addAll)100000 x 2 integers
-------------------------------------------------------
most                168.70 op/s ±  1.48%   (77 samples)

multicast -> combine(addAll)100000 x 3 integers
-------------------------------------------------------
most                103.61 op/s ±  1.60%   (78 samples)

multicast -> combine(addAll)100000 x 4 integers
-------------------------------------------------------
most                 76.59 op/s ±  1.55%   (71 samples)

multicast -> combine(addAll)100000 x 5 integers
-------------------------------------------------------
most                 56.68 op/s ±  1.71%   (71 samples)

multicast -> combine(addAll)100000 x 10 integers
-------------------------------------------------------
most                  7.38 op/s ±  1.86%   (39 samples)
```

This also fixes #14 
Close #15
