### PR TITLE
Update peer deps in prep for most 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "uglify-js": "^2.6.1"
   },
   "peerDependencies": {
-    "most": "^0.19.0"
+    "most": "^0.19.0 || ^1.0.0"
   },
   "dependencies": {
     "@most/prelude": "^1.2.0"


### PR DESCRIPTION
This allows either most 0.19.x or 1.x.x as a peerDep to pave the way for most 1.0 (See https://github.com/cujojs/most/pull/295)
