### PR TITLE
chore(README): deprecate multicast package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# ⚠️ Deprecated ⚠️
+ 
+`@most/multicast` is deprecated.
+
+Support and maintenance will cease when `@most/core` 1.0 is released. Meanwhile, only critical bug fixes will be released. 
+
+Its functionality is currently available in [@most/core](http://mostcore.readthedocs.io/en/latest/api.html#multicast) and will also be available in most 2.0.
+
 # @most/multicast
 
 Efficient source sharing of an underlying stream to multiple observers.


### PR DESCRIPTION
- [x] just need to populate the docs in `@most/core` with multicast